### PR TITLE
Retrieve linker options from bitcode archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SOURCE_FILES=main.c macho_retriever.c macho_reader.c macho_util.c
 RETRIEVER_BIN=$(BUILD_DIR)/bitcode_retriever
 
 all: $(BUILD_DIR)
-	$(CC) $(SOURCE_FILES) -o $(RETRIEVER_BIN) -lxar
+	$(CC) $(SOURCE_FILES) -o $(RETRIEVER_BIN) -lxar -lxml2
 
 ### Testing
 

--- a/macho_reader.h
+++ b/macho_reader.h
@@ -29,8 +29,10 @@ uint32_t offset_for_arch(FILE *stream, const int index, const int swap_bytes);
 struct mach_header *load_mach_header(FILE *stream, const int offset, const int swap_bytes);
 struct mach_header_64 *load_mach_header_64(FILE *stream, const int offset, const int swap_bytes);
 
-struct segment_command *load_llvm_segment_command(FILE *stream, struct mach_header *header, const int offset, const int swap_bytes);
-struct segment_command_64 *load_llvm_segment_command_64(FILE *stream, struct mach_header_64 *header, const int offset, const int swap_bytes);
+struct segment_command *load_llvm_segment_command(FILE *stream, struct mach_header *header, const int offset,
+                                                  const int swap_bytes);
+struct segment_command_64 *load_llvm_segment_command_64(FILE *stream, struct mach_header_64 *header, const int offset,
+                                                        const int swap_bytes);
 
 #ifdef __cplusplus
 }

--- a/macho_util.h
+++ b/macho_util.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <libxml/tree.h>
 #include "macho_retriever.h"
 
 char *fname(const char *name, const char *ext);
@@ -12,6 +13,11 @@ char *write_to_xar(struct bitcode_archive *bitcode);
 
 int extract_xar(const char *path, const char *cpu, char *files[], int *count);
 int write_to_bitcode(struct bitcode_archive *bitcode, char *files[], int *count);
+
+int get_options(xmlNode *option_parent, char *options[], int *size);
+int get_linker_options(xmlNode *a_node, char *options[], int *size);
+int retrieve_toc(const char *xar_path, const char *toc_path);
+int retrieve_linker_options(const char *xar_path, char *options[], int *size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The TOC of a bitcode archive contains linker options required for (re)building the final binary. This PR enables the extraction of linker commands from the archive. 
